### PR TITLE
Error for plotting experiment2 (dief@k)

### DIFF
--- a/R/reproduceExperiments.R
+++ b/R/reproduceExperiments.R
@@ -189,7 +189,7 @@ plotExperiment2Test <- function(diefkDF, q, colors=c("#ECC30B","#D56062","#84BCD
   maxs <- data.frame(diefk25=max(x$diefk25), diefk50=max(x$diefk50), diefk75=max(x$diefk75), diefk100=max(x$diefk100))
   mins <- data.frame(diefk25=0, diefk50=0,  diefk75=0, diefk100=0)
   
-  data <- rbind(mins, maxs, x)
+  data <- rbind(maxs, mins, x)
   
   colors_border=colors
   colors_in=alpha(colors_border, 0.15)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To download the development version of the `dief` package directly from GitHub, 
 # If you have not installed the "devtools" package.
 install.packages("devtools")
 # Install the dief package.
-devtools::install_github("maribelacosta/dief")
+devtools::install_github("dachafra/dief")
 ```
 
 ## Examples 


### PR DESCRIPTION
With current data loading process, data matrix is: min, max, data. For example, for mi case of 3 different engines (R, FR, FR+):
|| diefk25 | diefk50          | diefk75          | diefk100         |                  
|---------|------------------|------------------|------------------|------------------|
| min       | 0                | 0                | 0                | 0                |
| max       | 15498.1415426736 | 70239.2440954459 | 166073.514216197 | 297887.668403664 |
| R       | 15498.1415426736 | 70239.2440954459 | 166073.514216197 | 297887.668403664 |
| FR       | 9913.45131182668 | 36233.7311514595 | 86282.0688279842 | 154782.699403054 |
| FR+       | 5476.70262777804 | 31082.6195700179 | 58283.5948752244 | 94252.9999567334 |

The output plot is incorrect:
![incorrect](https://user-images.githubusercontent.com/12400271/82254233-be761880-9952-11ea-9aa5-a6d34d32a95f.png)

Loading the data as data<-(maxs,mins,data) the output is correct (lower is best):
![correct](https://user-images.githubusercontent.com/12400271/82254499-393f3380-9953-11ea-885e-ca38e29ab00d.png)


