### PR TITLE
dief@t adds additional data point with wrong timestamp

### DIFF
--- a/R/dief.R
+++ b/R/dief.R
@@ -46,9 +46,6 @@ dieft <- function(inputtrace, inputtest, t=-1) {
         k <- 0
       }
     }
-    com <- data.frame(t, k)
-    names(com) <- c("time", "answer")
-    subtrace <- rbind(subtrace, com)
     dieft <- 0
     if (nrow(subtrace) > 1) {
       dieft <- flux::auc(subtrace$time, subtrace$answer)

--- a/R/dief.R
+++ b/R/dief.R
@@ -14,7 +14,7 @@
 #' dieft(traces, "Q9.sparql")
 #' # Compute dief@t after 7.5 time units (seconds) of execution. 
 #' dieft(traces, "Q9.sparql", 7.5) 
-dieft <- function(inputtrace, inputtest, t=-1) {
+dieft <- function(inputtrace, inputtest, t=-1, to_end=TRUE) {
   
   # Initialize output structure.
   test <- NULL
@@ -45,6 +45,11 @@ dieft <- function(inputtrace, inputtest, t=-1) {
       if (subtrace$answer==0) {
         k <- 0
       }
+    }
+    if (to_end) {
+      com <- data.frame(t, k)
+      names(com) <- c("time", "answer")
+      subtrace <- rbind(subtrace, com)
     }
     dieft <- 0
     if (nrow(subtrace) > 1) {


### PR DESCRIPTION
The implementation of dief@t adds an additional data point for each approach with the maximum time t, where t is either the parameter given or the maximum t of all approaches. This leads to wrong values of dief@t if an approach finishes earlier than the others.

Assuming the following data
| approach | answer | time        |
|----------|--------|-------------|
| a1       |       1   | 379956750.0 |
| a1 | ... | ... |
| a1       | 2746   | 379966378.0 |
| a2       | 1   | 61117396.0  |
| a2 | ... | ... |
| a2       | 2746   | 61117396.0  |

Approach a1 is less efficient but is generates answers continuously while a2 is a blocking approach. The current implementation adds the data points **(a1, 2746, 379966378.0)** and **(a2, 2746, 379966378.0)**. Hence, the area-under-the-curve and the value for dief@t for a2 is higher than the one for a1 which is clearly wrong. The value of dief@t for a2 should be 0.0. This PR provides the necessary changes to fix this issue.